### PR TITLE
Ct redenom

### DIFF
--- a/config/env/common.js
+++ b/config/env/common.js
@@ -18,8 +18,8 @@ configOut = {
   logPass: process.env.LOGPASS ? process.env.LOGPASS : 'test',
 
   // These variables determine the exchange rate curve.
-  TOKENS_QTY_ORIGINAL: 50000,
-  BCH_QTY_ORIGINAL: 250,
+  TOKENS_QTY_ORIGINAL: 25000,
+  BCH_QTY_ORIGINAL: 125,
 
   // Email notifications settings.
   useEmailAlerts: process.env.USE_EMAIL_ALERTS

--- a/test/unit/use-cases/tl-main-use-case-unit.js
+++ b/test/unit/use-cases/tl-main-use-case-unit.js
@@ -50,7 +50,8 @@ describe('#tl-main-use-cases', () => {
       const result = await uut.getEffectiveTokenBalance(bchBalance)
       // console.log('result: ', result)
 
-      assert.equal(result, 149996.31356401)
+      // assert.equal(result, 149996.31356401)
+      assert.equal(result, 57669.477268)
     })
 
     it('should throw error if bchBalance is not provided', async () => {

--- a/test/unit/use-cases/trade-use-case-unit.js
+++ b/test/unit/use-cases/trade-use-case-unit.js
@@ -389,8 +389,8 @@ describe('#trade-use-cases', () => {
 
   // Based on the equation-visualizations.ods spreadsheet. These numbers come
   // from the logarithmic part of the curve.
-  describe('exchangeBCHForTokens', () => {
-    it('should calculate log values in the spreadsheet', () => {
+  describe('#exchangeBCHForTokens', () => {
+    it('should calculate log values in the spreadsheet 1', () => {
       const inObj = {
         bchQty: 7.86785736,
         state: {
@@ -403,14 +403,15 @@ describe('#trade-use-cases', () => {
 
       assert.equal(
         Math.floor(result),
-        49999,
+        // 49999,
+        24999,
         'Should match spreadsheet'
       )
     })
 
     // Based on the equation-visualizations.ods spreadsheet. These numbers come
     // from the log part of the curve.
-    it('should calculate log values in the spreadsheet', () => {
+    it('should calculate log values in the spreadsheet 2', () => {
       const inObj = {
         bchQty: 11.81408491,
         state: {
@@ -423,14 +424,15 @@ describe('#trade-use-cases', () => {
 
       assert.equal(
         Math.floor(result),
-        4999,
+        // 4999,
+        2499,
         'Should match spreadsheet'
       )
     })
 
     // Based on the equation-visualizations.ods spreadsheet. These numbers come
     // from the linear part of the curve.
-    it('should calculate linear values in the spreadsheet', () => {
+    it('should calculate linear values in the spreadsheet 3', () => {
       const inObj = {
         bchQty: 25,
         state: {
@@ -462,7 +464,8 @@ describe('#trade-use-cases', () => {
 
       assert.equal(
         Math.floor(result),
-        1709
+        // 1709
+        854
       )
     })
 
@@ -490,8 +493,11 @@ describe('#trade-use-cases', () => {
       // console.log('result: ', result)
 
       // 4.57 - 1.68 = 2.89
-      assert.isAbove(result, 2.89)
-      assert.isBelow(result, 3)
+      // assert.isAbove(result, 2.89)
+      // assert.isBelow(result, 3)
+
+      assert.isAbove(result, 2.5)
+      assert.isBelow(result, 4)
     })
 
     it('should calculate log values in the spreadsheet', () => {
@@ -506,8 +512,11 @@ describe('#trade-use-cases', () => {
       // console.log('result: ', result)
 
       // 124.146 - 112.332 = 11.814
-      assert.isAbove(result, 11.8)
-      assert.isBelow(result, 12)
+      // assert.isAbove(result, 11.8)
+      // assert.isBelow(result, 12)
+
+      assert.isAbove(result, 22)
+      assert.isBelow(result, 23)
     })
 
     it('should calculate linear values in the spreadsheet', () => {


### PR DESCRIPTION
This PR switches the base values of 250/50000 to 125/25000 (50% change). The point of this change is to remove the amount of money in the token-liquidity app while keeping the token price the same. This reduces the BCH 'at-risk' in the token-liquidity app.